### PR TITLE
Add a TransferCanceled event

### DIFF
--- a/src/NTwain/Internals/ITwainSessionInternal.cs
+++ b/src/NTwain/Internals/ITwainSessionInternal.cs
@@ -41,6 +41,7 @@ namespace NTwain.Internals
         ReturnCode DisableSource();
 
         void SafeSyncableRaiseEvent(DataTransferredEventArgs e);
+        void SafeSyncableRaiseEvent(TransferCanceledEventArgs e);
         void SafeSyncableRaiseEvent(TransferErrorEventArgs e);
         void SafeSyncableRaiseEvent(TransferReadyEventArgs e);
 

--- a/src/NTwain/Internals/TransferLogic.cs
+++ b/src/NTwain/Internals/TransferLogic.cs
@@ -145,8 +145,10 @@ namespace NTwain.Internals
             {
                 case ReturnCode.Success:
                 case ReturnCode.XferDone:
-                case ReturnCode.Cancel:
                     // ok to keep going
+                    break;
+                case ReturnCode.Cancel:
+                    session.SafeSyncableRaiseEvent(new TransferCanceledEventArgs());
                     break;
                 default:
                     var status = session.CurrentSource.GetStatus();

--- a/src/NTwain/TransferCanceledEventArgs.cs
+++ b/src/NTwain/TransferCanceledEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace NTwain
+{
+    /// <summary>
+    /// Indicates a transfer cancellation, e.g. if the user pressed the "Cancel" button.
+    /// </summary>
+    public class TransferCanceledEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransferCanceledEventArgs"/> class.
+        /// </summary>
+        public TransferCanceledEventArgs()
+        {
+        }
+    }
+}

--- a/src/NTwain/TwainSession.cs
+++ b/src/NTwain/TwainSession.cs
@@ -482,6 +482,10 @@ namespace NTwain
         /// </summary>
         public event EventHandler<DataTransferredEventArgs> DataTransferred;
         /// <summary>
+        /// Occurs when a transfer was canceled.
+        /// </summary>
+        public event EventHandler<TransferCanceledEventArgs> TransferCanceled;
+        /// <summary>
         /// Occurs when an error has been encountered during transfer.
         /// </summary>
         public event EventHandler<TransferErrorEventArgs> TransferError;
@@ -679,6 +683,12 @@ namespace NTwain
         /// </summary>
         /// <param name="e">The <see cref="DataTransferredEventArgs"/> instance containing the event data.</param>
         protected virtual void OnDataTransferred(DataTransferredEventArgs e) { }
+
+        /// <summary>
+        /// Called when a transfer was canceled.
+        /// </summary>
+        /// <param name="e">The <see cref="TransferCanceledEventArgs"/> instance containing the event data.</param>
+        protected virtual void OnTransferCanceled(TransferCanceledEventArgs e) { }
 
         /// <summary>
         /// Called when an error has been encountered during transfer.

--- a/src/NTwain/TwainSessionInternal.cs
+++ b/src/NTwain/TwainSessionInternal.cs
@@ -96,6 +96,10 @@ namespace NTwain
         {
             SafeSyncableRaiseOnEvent(OnDataTransferred, DataTransferred, e);
         }
+        void ITwainSessionInternal.SafeSyncableRaiseEvent(TransferCanceledEventArgs e)
+        {
+            SafeSyncableRaiseOnEvent(OnTransferCanceled, TransferCanceled, e);
+        }
         void ITwainSessionInternal.SafeSyncableRaiseEvent(TransferErrorEventArgs e)
         {
             SafeSyncableRaiseOnEvent(OnTransferError, TransferError, e);


### PR DESCRIPTION
For memory transfer this helps differentiate between "incomplete data because the real scan area was smaller than reported" and "incomplete data because the scan was cancelled".