### PR TITLE
Fix duplicate values in SupportedSize enum

### DIFF
--- a/src/NTwain/Data/TwainValues.cs
+++ b/src/NTwain/Data/TwainValues.cs
@@ -1103,7 +1103,7 @@ namespace NTwain.Data
         IsoB5 = 29,
         IsoB7 = 30,
         IsoB8 = 31,
-        IsoB9 = 31,
+        IsoB9 = 32,
         IsoB10 = 33,
         JisB0 = 34,
         JisB1 = 35,


### PR DESCRIPTION
Both IsoB8 and IsoB9 SupportedSizes were set to 31. Updated IsoB9 to 32 to match the TWAIN spec.