### PR TITLE
fix image scanning pending count

### DIFF
--- a/src/NTwain/Internals/TransferLogic.cs
+++ b/src/NTwain/Internals/TransferLogic.cs
@@ -54,7 +54,16 @@ namespace NTwain.Internals
             #endregion
 
             var pending = new TWPendingXfers();
-            var rc = session.DGControl.PendingXfers.Get(pending);
+            ReturnCode rc;
+            if (xferImage)
+            {
+                rc = ReturnCode.Success;
+            }
+            else
+            {
+                rc = session.DGControl.PendingXfers.Get(pending);
+            }
+
             if (rc == ReturnCode.Success)
             {
                 do

--- a/src/NTwain/Internals/TransferLogic.cs
+++ b/src/NTwain/Internals/TransferLogic.cs
@@ -54,15 +54,7 @@ namespace NTwain.Internals
             #endregion
 
             var pending = new TWPendingXfers();
-            ReturnCode rc;
-            if (xferImage)
-            {
-                rc = ReturnCode.Success;
-            }
-            else
-            {
-                rc = session.DGControl.PendingXfers.Get(pending);
-            }
+            var rc = xferImage ? ReturnCode.Success : session.DGControl.PendingXfers.Get(pending);
 
             if (rc == ReturnCode.Success)
             {


### PR DESCRIPTION
fix for #58

While scanning from various multi page scanners(HP) only first page is returned because `DG_CONTROL / DAT_PENDINGXFERS / MSG_GET` is returning 1. Removed this check for image scanning, as it is not required to check pending count while entering loop.