### PR TITLE
Fix: CloseDSMAsync() hang in TwainAppSession

### DIFF
--- a/src/NTwain/MessagePumpThread.cs
+++ b/src/NTwain/MessagePumpThread.cs
@@ -69,12 +69,12 @@ namespace NTwain
     /// <summary>
     /// Detatches a previously attached session and stops the thread.
     /// </summary>
-    public async Task<STS> DetatchAsync()
+    public async Task<STS> DetachAsync()
     {
       STS sts = default;
       if (_dummyForm != null && _twain != null)
       {
-        TaskCompletionSource<bool> tcs = new();
+        TaskCompletionSource<STS> tcs = new();
         _dummyForm.BeginInvoke(() =>
         {
           sts = _twain.CloseDSMReal();
@@ -84,6 +84,7 @@ namespace NTwain
             _dummyForm.Close();
             _twain = null;
           }
+          tcs.SetResult(sts);
         });
         await tcs.Task;
       }

--- a/src/NTwain/TwainAppSession.cs
+++ b/src/NTwain/TwainAppSession.cs
@@ -144,7 +144,7 @@ namespace NTwain
         {
             if (_selfPump == null) throw new InvalidOperationException($"Cannot close if not opened with {nameof(OpenDSMAsync)}().");
 
-            var sts = await _selfPump.DetatchAsync();
+            var sts = await _selfPump.DetachAsync();
             if (sts.IsSuccess)
             {
                 _selfPump = null;


### PR DESCRIPTION
Fixed problem with calls to `TwainAppSession.CloseDSMAsync()` never returning.